### PR TITLE
Upgrade AppAuth iOS version to 1.3.0.

### DIFF
--- a/Assets/UnityGoogleDrive/Editor/Dependencies.xml
+++ b/Assets/UnityGoogleDrive/Editor/Dependencies.xml
@@ -3,6 +3,6 @@
     <androidPackage spec="net.openid:appauth:0.7.+" />
   </androidPackages>
   <iosPods>
-    <iosPod name="AppAuth" version="~> 1.1.0" bitcodeEnabled="true" minTargetSdk="7.0" />
+    <iosPod name="AppAuth" version="~> 1.3.0" bitcodeEnabled="true" minTargetSdk="7.0" />
   </iosPods>
 </dependencies>


### PR DESCRIPTION
Hi, Thank you for your great repo.
Related to #63, I faced the same problem with AppAuth 1.1.0 and iPad OS 13.3.1.
After I use AppAuth  1.3.0 (latest), the issue was gone.
I think it's better to upgrade default AppAuth version for iOS to 1.3.0 if no concerns you have.
Thank you.