### PR TITLE
Add setup tip about Managed Stripping Level to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Automated integration tests cover the main features:
 
 ## Setup (editor, standalones and WebGL)
 - Import the package;
+- In the Unity Editor navigate to `Edit -> Settings -> Player - Other Settings` ensure that 'Managed Stripping Level' is set to Disabled/Minimal/Low and no higher than that (if the stripping is higher than Low, necessary JSON parsing will not work and the plugin may misbehave in builds only while working fine in the editor)
 - In the Unity editor navigate to `Edit -> Settings -> Google Drive`; **GoogleDriveSettings.asset** file will be automatically created at `Assets/UnityGoogleDrive/Resources`, select the file (if it wasn't selected automatically);
 - Click **Create Google Drive API app** button; web-browser will open URL to setup the app:
   - Select **Create a new project** and click continue;


### PR DESCRIPTION
Add setup tip about Managed Stripping Level - Related to the following issues where I found that only in builds the app would not be able to parse JSON things such as the id of uploaded files or perform requests to get files etc.

https://github.com/Elringus/UnityGoogleDrive/issues/95
https://github.com/Elringus/UnityGoogleDrive/issues/96

I discovered that the issue was actually caused by Managed Stripping Level being higher than 'Low', and wanted to update the Readme for this. Feel free to make changes as you need, there should be some way to ensure the required stuff for JSON reading should be included in even a stripped build through the plugin but currently I am not sure what is being stripped that is required for that or how to mark it to be included in builds with the plugin.